### PR TITLE
155 bug display the project name instead of the project id in the project page

### DIFF
--- a/backend/modules/dataProviders/webDataProvider/useCases/selections.py
+++ b/backend/modules/dataProviders/webDataProvider/useCases/selections.py
@@ -7,15 +7,17 @@ def get_project_selections(url, project_id):
         selections = api.get_selections(url, project_id)
 
         if selections is None:
-            print(
-                "Error: No selections found for project {} on {}".format(
-                    project_id, url
-                )
-            )
+            print(f"Error: No selections found for project {project_id} on {url}")
             raise DataProviderException("No selections found", 404)
 
         debiai_selections = []
         for selection in selections:
+            if "id" not in selection or selection["id"] is None:
+                print(f"Error: No id for selection: {selection}")
+                raise DataProviderException(
+                    "An id is missing in the given selection", 400
+                )
+
             selection_to_add = {
                 "name": selection["name"] if "name" in selection else selection["id"],
                 "id": selection["id"],
@@ -30,7 +32,8 @@ def get_project_selections(url, project_id):
 
             debiai_selections.append(selection_to_add)
         return debiai_selections
-    except DataProviderException as e:
+
+    except DataProviderException:
         # The route may not be implemented in the data provider
         return []
 

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 0.26.0-beta5
+  version: 0.26.0-beta6
   title: DebiAI_BACKEND_API
   description: DebiAI backend api
   contact:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debiai_frontend",
-  "version": "0.26.0-beta5",
+  "version": "0.26.0-beta6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "debiai_frontend",
-      "version": "0.26.0-beta5",
+      "version": "0.26.0-beta6",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debiai_frontend",
-  "version": "0.26.0-beta5",
+  "version": "0.26.0-beta6",
   "description": "Frontend for Debiai, made with Vuejs",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>DebiAI</title>
 
     <!-- Imports -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/frontend/src/components/debiai/dataAnalysis/Header.vue
+++ b/frontend/src/components/debiai/dataAnalysis/Header.vue
@@ -30,12 +30,7 @@
       <!-- DebiAI Logo -->
       <router-link
         id="debiaiLogo"
-        :to="
-          '/dataprovider/' +
-          $store.state.ProjectPage.dataProviderId +
-          '/project/' +
-          $store.state.ProjectPage.projectId
-        "
+        to="/"
       >
         <img
           src="@/assets/images/DebiAI_black.png"
@@ -55,7 +50,11 @@
             '/project/' +
             $store.state.ProjectPage.projectId
           "
-          >{{ $store.state.ProjectPage.projectId }}</router-link
+          >{{
+            $store.state.ProjectPage.projectName
+              ? $store.state.ProjectPage.projectName
+              : $store.state.ProjectPage.projectId
+          }}</router-link
         >
         / Analysis
       </div>

--- a/frontend/src/components/debiai/frontpage/FrontPage.vue
+++ b/frontend/src/components/debiai/frontpage/FrontPage.vue
@@ -277,6 +277,9 @@ export default {
   created() {
     // Load the projects
     this.loadProjects();
+
+    // Change the browser title
+    document.title = "DebiAI";
   },
   methods: {
     loadProjects() {

--- a/frontend/src/components/debiai/project/Project.vue
+++ b/frontend/src/components/debiai/project/Project.vue
@@ -194,6 +194,7 @@ export default {
           // Store some info
           this.$store.commit("setProjectColumns", this.project.columns);
           this.$store.commit("setProjectResultsColumns", this.project.resultStructure);
+          this.$store.commit("setProjectName", this.project.name);
 
           // Change the browser title
           if (this.project.name) document.title = this.project.name;

--- a/frontend/src/components/debiai/project/Project.vue
+++ b/frontend/src/components/debiai/project/Project.vue
@@ -194,6 +194,10 @@ export default {
           // Store some info
           this.$store.commit("setProjectColumns", this.project.columns);
           this.$store.commit("setProjectResultsColumns", this.project.resultStructure);
+
+          // Change the browser title
+          if (this.project.name) document.title = this.project.name;
+          else document.title = this.project.id;
         })
         .catch((e) => {
           if (e.response && e.response.status === 500) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -25,10 +25,5 @@ let router = new Router({
     },
   ],
 });
-const DEFAULT_TITLE = "DebiAI";
-router.beforeEach((to, from, next) => {
-  document.title = to.query.projectId || to.params.projectId || DEFAULT_TITLE;
-  next();
-});
 
 export default router;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -63,6 +63,7 @@ const Dashboard = {
 const ProjectPage = {
   state: {
     projectId: null,
+    projectName: null,
     dataProviderId: null,
     selectionsIds: [],
     projectColumns: [],
@@ -73,6 +74,9 @@ const ProjectPage = {
   mutations: {
     setProjectId(state, projectId) {
       state.projectId = projectId;
+    },
+    setProjectName(state, projectName) {
+      state.projectName = projectName;
     },
     setDataProviderId(state, dataProviderId) {
       state.dataProviderId = dataProviderId;


### PR DESCRIPTION
## Describe your changes
Fixed project id displaying in the document title and analysis page when the project name was available.

## Screenshots (if appropriate):
What have been fixed :
![image](https://github.com/debiai/debiai/assets/59999324/7aa34c15-87a8-4569-86df-e6f1867a0878)
![image](https://github.com/debiai/debiai/assets/59999324/397ba591-0a97-4683-b4b3-94b027edeeb4)

## Issue ticket number and link
#155

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have increased the version number in the `frontend/package.json` and `backend/swagger.yaml` files
- [x] I have checked that Black, Prettier and Cspell have been run on my code
