### PR TITLE
144 be able to save correlation matrix widget configuration

### DIFF
--- a/frontend/src/components/debiai/dataAnalysis/DataAnalysis.vue
+++ b/frontend/src/components/debiai/dataAnalysis/DataAnalysis.vue
@@ -80,7 +80,7 @@
     </modal>
     <!-- WidgetCatalog -->
     <modal
-      v-show="widgetCatalog"
+      v-if="widgetCatalog"
       @close="widgetCatalog = false"
       :preventBodyScroll="false"
     >

--- a/frontend/src/components/debiai/dataAnalysis/widget/widgetConfigurationCreation/WidgetConfPanel.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widget/widgetConfigurationCreation/WidgetConfPanel.vue
@@ -81,13 +81,11 @@ export default {
   },
   data() {
     return {
-      newWidgetName: "",
       configurations: [], // [{ id, name, description, configuration, projectId, dataProviderId, creationDate }]
     };
   },
   created() {
     this.loadWidgetConfigurations();
-    this.newWidgetName = this.widgetName;
   },
   methods: {
     loadWidgetConfigurations() {
@@ -103,7 +101,7 @@ export default {
         });
     },
     handleConfSaved(confName) {
-      this.newWidgetName = confName;
+      this.$emit("saved", confName);
       this.loadWidgetConfigurations();
     },
   },

--- a/frontend/src/components/debiai/dataAnalysis/widget/widgetConfigurationCreation/WidgetConfPanel.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widget/widgetConfigurationCreation/WidgetConfPanel.vue
@@ -35,7 +35,11 @@
           :widgetTitle="widgetTitle"
           :widgetKey="widgetKey"
           :suggestedConfName="suggestedConfName"
-          @saved="(confName) => $emit('saved', confName)"
+          @saved="
+            (confName) => {
+              handleConfSaved(confName);
+            }
+          "
           class="card"
         />
       </div>
@@ -97,6 +101,10 @@ export default {
         .catch((e) => {
           console.log(e);
         });
+    },
+    handleConfSaved(confName) {
+      this.newWidgetName = confName;
+      this.loadWidgetConfigurations();
     },
   },
 };

--- a/frontend/src/components/debiai/dataAnalysis/widgets/CorrelationMatrix/CorrelationMatrix.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widgets/CorrelationMatrix/CorrelationMatrix.vue
@@ -273,6 +273,37 @@ export default {
       this.$parent.$emit("drawn");
       this.matrixDrawn = true;
     },
+    // Conf
+    getConf() {
+      let conf = {
+        selectedColumns: this.selectedColumns.map((c) => c.index),
+        selectedMatrixType: this.selectedMatrixType,
+        significativeOnly: this.significativeOnly,
+      };
+
+      return conf;
+    },
+    setConf(conf) {
+      if (!conf) return;
+      if ("selectedColumns" in conf) {
+        this.selectedColumns = conf.selectedColumns
+          .map((colId) => {
+            const column = this.data.columns.find((col) => col.index == colId);
+            if (!column) {
+              this.$store.commit("sendMessage", {
+                title: "warning",
+                msg: "The selected column " + colId + " hasn't been found",
+              });
+            }
+            return column;
+          })
+          .filter((column) => column && column.nbOccurrence > 1);
+      }
+      if ("selectedMatrixType" in conf) this.selectedMatrixType = conf.selectedMatrixType;
+      if ("significativeOnly" in conf) this.significativeOnly = conf.significativeOnly;
+
+      this.calculate();
+    },
 
     // Export
     async getImage() {


### PR DESCRIPTION
## Describe your changes
Combined two issues into one ticket. Initial issue fixed by implementing getters and setters for the correlation matrix widget so it is saved successfully. Second issue was to update the configuration interface when saved.
## Screenshots (if appropriate):

## Issue ticket number and link
144 
https://github.com/debiai/debiai/issues/144
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have increased the version number in the `frontend/package.json` and `backend/swagger.yaml` files
- [x] I have checked that Black, Flake8, Prettier and Cspell are passing
