### PR TITLE
198 make web data providers support creation date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-TODO
 dist/
 deployment/
 .vscode/

--- a/backend/modules/dataProviders/webDataProvider/useCases/models.py
+++ b/backend/modules/dataProviders/webDataProvider/useCases/models.py
@@ -12,8 +12,8 @@ def get_models_info(url, project_id):
                 continue
             model = {
                 "id": model_in["id"],
-                # "creationDate": TODO,
-                # "updateDate": TODO
+                "metadata": None,
+                "creationDate": None,
             }
 
             # Adding name and nbResults
@@ -22,10 +22,12 @@ def get_models_info(url, project_id):
                 model["nbResults"] = model_in["nbResults"]
 
             # Adding metadata
-            if "metadata" not in model_in:
-                model["metadata"] = None
-            else:
+            if "metadata" in model_in:
                 model["metadata"] = model_in["metadata"]
+
+            # Adding creationDate
+            if "creationDate" in model_in:
+                model["creationDate"] = model_in["creationDate"]
 
             debiai_models.append(model)
 

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 0.27.0
+  version: 0.27.1
   title: DebiAI_BACKEND_API
   description: DebiAI backend api
   contact:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debiai_frontend",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Frontend for Debiai, made with Vuejs",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/src/components/common/DocumentationBlock .vue
+++ b/frontend/src/components/common/DocumentationBlock .vue
@@ -93,6 +93,8 @@ export default {
   font-weight: normal;
   box-shadow: 0px 0px 25px rgba(0, 0, 0, 0.1);
   max-width: 500px;
+  max-height: 500px;
+  overflow-y: auto;
 }
 
 #docBlock.top {

--- a/frontend/src/components/debiai/project/Models.vue
+++ b/frontend/src/components/debiai/project/Models.vue
@@ -61,7 +61,7 @@
             </span>
           </div>
           <!-- Model Metadata -->
-          <DocumentationBlock v-if="model.metadata && Object.keys(model.metadata).length > 0">
+          <DocumentationBlock v-if="model.metadata && Object.keys(model.metadata)">
             <h4>Model Metadata</h4>
             <br />
             <div style="white-space: pre-wrap">


### PR DESCRIPTION
## Describe your changes
Web data-provider now support `creationDate` field
Added a max height to documentation block component
Other improvements

## Screenshots (if appropriate):
![image](https://github.com/debiai/DebiAI/assets/59999324/870239d8-fd7a-4883-b2f9-213b05207446)

## Issue ticket number and link
#198 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have increased the version number in the `frontend/package.json` and `backend/swagger.yaml` files
- [x] I have checked that Black, Flake8, Prettier and Cspell are passing
