### PR TITLE
Array widget improvements

### DIFF
--- a/debiaiServer/swagger.yaml
+++ b/debiaiServer/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 0.28.1
+  version: 0.29.0-beta1
   title: DebiAI_BACKEND_API
   description: DebiAI backend api
   contact:

--- a/frontend/cspell.json
+++ b/frontend/cspell.json
@@ -41,6 +41,7 @@
     "ncontours",
     "parcats",
     "parcoords",
+    "psutil",
     "rangeslider",
     "relayout",
     "resizestop",
@@ -80,8 +81,7 @@
     "zeroline",
     "Zindex",
     "zmax",
-    "zmin",
-    "psutil"
+    "zmin"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debiai_frontend",
-  "version": "0.28.1",
+  "version": "0.29.0-beta1",
   "description": "Frontend for Debiai, made with Vuejs",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,6 @@
     "vue-inline-svg": "^2.0.0",
     "vue-progressive-image": "^3.2.0",
     "vue-router": "^3.3.4",
-    "vue-table-dynamic": "^0.4.4",
     "vuex": "^3.5.1"
   },
   "devDependencies": {

--- a/frontend/src/components/debiai/dataAnalysis/common/ColumnSelection.vue
+++ b/frontend/src/components/debiai/dataAnalysis/common/ColumnSelection.vue
@@ -111,7 +111,6 @@ export default {
     } else {
       this.selectedColumns = this.defaultSelected;
     }
-    document.addEventListener("keydown", this.keyHandler);
   },
   mounted() {
     // Set focus on search bar
@@ -119,10 +118,6 @@ export default {
   },
 
   methods: {
-    // Handles the keydown event and emits the "cancel" event when the Escape key is pressed
-    keyHandler(k) {
-      if (k.key == "Escape") this.$emit("cancel");
-    },
     // Handles the selection of a column and emits the "colSelect" event with the selected column index
     columnSelected(colIndex) {
       this.$emit("colSelect", colIndex);
@@ -232,9 +227,6 @@ export default {
     defaultSelected() {
       if (this.defaultSelected) this.selectedColumns = this.defaultSelected;
     },
-  },
-  beforeDestroy() {
-    document.removeEventListener("keydown", this.keyHandler);
   },
 };
 </script>

--- a/frontend/src/components/debiai/dataAnalysis/dataFilters/filterTypes/FilterGenericData.vue
+++ b/frontend/src/components/debiai/dataAnalysis/dataFilters/filterTypes/FilterGenericData.vue
@@ -11,7 +11,13 @@
         :class="'aligned centered ' + (filter.type === 'intervals' ? 'intervalCol' : 'valueCol')"
         title="Column name"
       >
-        {{ filter.column.label }}
+        <span v-if="filter.column && filter.column.label">
+          {{ filter.column.label }}
+        </span>
+        <span v-else>
+          Column not found
+          <!-- TODO Prevent this from happening -->
+        </span>
       </div>
     </div>
 

--- a/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
@@ -49,7 +49,7 @@
 
       <!-- Pagination -->
       <div class="pagination">
-        <span style="width: 70px">
+        <span style="width: 50px">
           <button
             v-if="currentPage > 0"
             @click="pageDown"
@@ -57,8 +57,13 @@
             ◀
           </button>
         </span>
-        <span class="pageDisplayer">{{ currentPage + 1 }} / {{ maxPage + 1 }}</span>
-        <span style="width: 70px">
+        <span
+          class="pageDisplayer"
+          title="Jump to page"
+          @click="pageToJumpTo = currentPage + 1"
+          >{{ currentPage + 1 }} / {{ maxPage + 1 }}
+        </span>
+        <span style="width: 50px">
           <button
             v-if="currentPage < maxPage"
             @click="pageUp"
@@ -68,6 +73,34 @@
         </span>
       </div>
     </div>
+
+    <!-- Page selection modal -->
+    <modal
+      v-if="pageToJumpTo !== null"
+      @close="pageToJumpTo = null"
+    >
+      <div>
+        <h3 style="margin-bottom: 10px; display: flex; justify-content: space-between; gap: 10px">
+          Jump to page
+          <button
+            @click="pageToJumpTo = null"
+            class="red"
+          >
+            Cancel
+          </button>
+        </h3>
+        <form @submit.prevent="jumpToPage">
+          <input
+            type="number"
+            v-model="pageToJumpTo"
+            min="1"
+            max="maxPage + 1"
+            style="padding: 5px"
+          />
+          <button type="submit">Jump</button>
+        </form>
+      </div>
+    </modal>
   </div>
 </template>
 
@@ -94,6 +127,8 @@ export default {
       currentSamplePosition: 0,
       dataPerPage: 0,
       maxPage: 0,
+
+      pageToJumpTo: null,
     };
   },
   created() {
@@ -179,6 +214,14 @@ export default {
       if (this.currentSamplePosition >= this.data.selectedData.length)
         this.currentSamplePosition = this.data.selectedData.length - this.dataPerPage;
     },
+    jumpToPage() {
+      if (this.pageToJumpTo <= 1) this.pageToJumpTo = 1;
+      if (this.pageToJumpTo > this.maxPage + 1) this.pageToJumpTo = this.maxPage + 1;
+
+      this.currentSamplePosition = (this.pageToJumpTo - 1) * this.dataPerPage;
+      this.updateArray();
+      this.pageToJumpTo = null;
+    },
   },
   computed: {
     selectedDataUpdate() {
@@ -254,8 +297,21 @@ export default {
     }
 
     .pageDisplayer {
+      width: 80px;
       padding: 8px 16px;
       font-size: 16px;
+      cursor: pointer;
+
+      &:hover {
+        background-color: #f2f2f2;
+        border-radius: 5px;
+      }
+    }
+
+    span {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   }
 }

--- a/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
@@ -77,7 +77,7 @@
           </button>
         </span>
         <span
-          class="pageDisplayer"
+          class="pageDisplay"
           title="Jump to page"
           @click="pageToJumpTo = currentPage + 1"
           >{{ currentPage + 1 }} / {{ maxPage + 1 }}
@@ -413,7 +413,7 @@ export default {
       cursor: pointer;
     }
 
-    .pageDisplayer {
+    .pageDisplay {
       padding: 8px 16px;
       font-size: 16px;
       cursor: pointer;

--- a/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
@@ -119,6 +119,7 @@ export default {
   data() {
     return {
       selectedColumnsIds: [],
+      selectedDataIds: [],
       settings: true,
       columnsSelection: false,
 
@@ -138,14 +139,21 @@ export default {
     this.$parent.$on("settings", () => {
       this.settings = !this.settings;
     });
-    this.$parent.$on("redraw", this.updateArray);
+    this.$parent.$on("redraw", this.drawArray);
     this.$parent.$parent.$on("GridStack_resizestop", () => {
       this.updateArray();
     });
   },
   methods: {
+    drawArray() {
+      // Copy the selected data array
+      this.selectedDataIds = this.data.selectedData.slice();
+      this.updateArray();
+      this.settings = false;
+      this.$parent.$emit("drawn");
+    },
     updateArray() {
-      if (this.data.selectedData.length === 0 || this.settings) return;
+      if (this.selectedDataIds.length === 0 || this.settings) return;
 
       // Get the number of rows to display and the height of the div
       const d = document.getElementById("SampleArray" + this.index) || null;
@@ -154,7 +162,7 @@ export default {
       this.dataPerPage = Math.floor((d.clientHeight * 0.95) / rowHeight) - 3; // Number of rows to display
 
       // Calculate the number of pages
-      this.maxPage = Math.ceil(this.data.selectedData.length / this.dataPerPage) - 1;
+      this.maxPage = Math.ceil(this.selectedDataIds.length / this.dataPerPage) - 1;
 
       // Get the labels of the columns
       this.selectedColumnsIds = this.selectedColumnsIds.filter((i) => this.data.columnExists(i));
@@ -163,7 +171,7 @@ export default {
       // Get the data to display
       this.adjustPagination();
 
-      const selectedData = this.data.selectedData.slice(
+      const selectedData = this.selectedDataIds.slice(
         this.currentSamplePosition,
         this.currentSamplePosition + this.dataPerPage
       );
@@ -178,16 +186,13 @@ export default {
       });
 
       this.arrayData = data;
-
-      this.settings = false;
-      this.$parent.$emit("drawn");
     },
     columnsSelect(columnIndexes) {
       this.selectedColumnsIds = columnIndexes;
 
       if (this.selectedColumnsIds.length > 0) {
         this.settings = false;
-        this.updateArray();
+        this.drawArray();
       }
     },
     pageUp() {
@@ -205,14 +210,14 @@ export default {
     },
     adjustPagination() {
       // If the currentSamplePosition is greater than the number of rows
-      if (this.currentSamplePosition >= this.data.selectedData.length)
-        this.currentSamplePosition = this.data.selectedData.length - this.dataPerPage;
+      if (this.currentSamplePosition >= this.selectedDataIds.length)
+        this.currentSamplePosition = this.selectedDataIds.length - this.dataPerPage;
 
       // After a resize, adjust the pagination to have the currentSamplePosition
       // In the start of the page
       this.currentSamplePosition = this.currentPage * this.dataPerPage;
-      if (this.currentSamplePosition >= this.data.selectedData.length)
-        this.currentSamplePosition = this.data.selectedData.length - this.dataPerPage;
+      if (this.currentSamplePosition >= this.selectedDataIds.length)
+        this.currentSamplePosition = this.selectedDataIds.length - this.dataPerPage;
     },
     jumpToPage() {
       if (this.pageToJumpTo <= 1) this.pageToJumpTo = 1;

--- a/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
+++ b/frontend/src/components/debiai/dataAnalysis/widgets/SampleArray/SampleArray.vue
@@ -49,9 +49,20 @@
 
       <!-- Pagination -->
       <div class="pagination">
-        <span style="width: 50px">
+        <span class="buttons">
           <button
-            v-if="currentPage > 0"
+            :disabled="!(currentPage > 0)"
+            @click="
+              currentSamplePosition = 0;
+              updateArray();
+            "
+          >
+            ◀◀
+          </button>
+        </span>
+        <span class="buttons">
+          <button
+            :disabled="!(currentPage > 0)"
             @click="pageDown"
           >
             ◀
@@ -63,12 +74,23 @@
           @click="pageToJumpTo = currentPage + 1"
           >{{ currentPage + 1 }} / {{ maxPage + 1 }}
         </span>
-        <span style="width: 50px">
+        <span class="buttons">
           <button
-            v-if="currentPage < maxPage"
+            :disabled="!(currentPage < maxPage)"
             @click="pageUp"
           >
             ▶
+          </button>
+        </span>
+        <span class="buttons">
+          <button
+            :disabled="!(currentPage < maxPage)"
+            @click="
+              currentSamplePosition = maxPage * dataPerPage;
+              updateArray();
+            "
+          >
+            ▶▶
           </button>
         </span>
       </div>
@@ -287,7 +309,8 @@ export default {
   .pagination {
     display: flex;
     justify-content: center;
-    margin: 10px 0px;
+    margin-bottom: 10px;
+    gap: 3px;
 
     button {
       background-color: #f2f2f2;
@@ -313,10 +336,19 @@ export default {
       }
     }
 
-    span {
+    .buttons {
       display: flex;
       justify-content: center;
       align-items: center;
+
+      width: 50px;
+      button {
+        width: 100%;
+        &:hover {
+          background-color: #f2f2f2;
+          border-radius: 5px;
+        }
+      }
     }
   }
 }

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ install:
 
 # Run the application in development mode
 run_debiaiServer:
-	cd debiaiServer && python websrv.py
+	python run_debiai_server_dev.py
 
 run_frontend:
 	cd frontend && npm run serve


### PR DESCRIPTION
## Describe your changes
The previous widget array was slow and buggy when there were many rows and columns to show.
I've completely remade it with the following features:
- The number of lines automatically increases or decreases when the widget size changes.
- Fast column sort by and reverse sort
- Pagination
- Displays quickly and is ram efficient
- Added get and set conf

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/35d91220-688d-43da-b0af-c4079d79f15d)
![image](https://github.com/user-attachments/assets/25a9541f-ec8c-4a0b-a7c4-2e9bd70ef283)
![image](https://github.com/user-attachments/assets/5ae0d4b7-1cab-4aa9-a66b-39324e50657a)

## Issue ticket number and link
#213 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have increased the version number in the `frontend/package.json` and `backend/swagger.yaml` files
- [x] I have checked that Black, Flake8, Prettier and Cspell are passing
